### PR TITLE
Added events service control requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,75 @@ The following example stops the calling program specifying a return code of
         service.stop (0);
     });
 
+## service.getState ()
+
+(Windows only)
+
+Gets the current state of the service, according to the OS. The return value can be one of:
+`stopped`, `start-pending`, `stop-pending`, `running`, `continue-pending`, `pause-pending`, or `paused`
+
+## service.setState (`state`)
+
+(Windows only)
+
+Informs the OS of the service's state.
+
+`state` can be `stopped`, `running`, or `paused`.
+
+Setting a value of `stopped` will stop the service by calling `service.stop(0)`
+
+## service.acceptControl (controlName[, add])
+
+(Windows only)
+
+Tells the OS this service accepts a control request with the code identified by `controlName`. If `add` is `false`, then
+the control code will no longer be received.
+
+See `service.on` for the list of control code names.
+
+## service.on (eventName, fn)
+
+(Windows only)
+
+Adds a listener function `fn` which gets called with `fn(eventName[, eventType])` when the services receives a
+[control request](https://docs.microsoft.com/windows/win32/services/service-control-requests). For convenience,
+`service.acceptControl` will automatically be called with `eventName`.
+
+The following lists the events can be emitted, along with their corresponding control code (see
+[ControlService](https://docs.microsoft.com/windows/win32/api/winsvc/nf-winsvc-controlservice)):
+
+* `start`: Emitted when the service has started.
+* `stop`: SERVICE_CONTROL_STOP
+* `pause`: SERVICE_CONTROL_PAUSE
+* `continue`: SERVICE_CONTROL_CONTINUE
+* `interrogate`: SERVICE_CONTROL_INTERROGATE
+* `shutdown`: SERVICE_CONTROL_SHUTDOWN
+* `paramchange`: SERVICE_CONTROL_PARAMCHANGE
+* `netbindadd`: SERVICE_CONTROL_NETBINDADD
+* `netbindremove`: SERVICE_CONTROL_NETBINDREMOVE
+* `netbindenable`: SERVICE_CONTROL_NETBINDENABLE
+* `netbinddisable`: SERVICE_CONTROL_NETBINDDISABLE
+* `deviceevent`: SERVICE_CONTROL_DEVICEEVENT
+* `hardwareprofilechange`: SERVICE_CONTROL_HARDWAREPROFILECHANGE
+* `powerevent`: SERVICE_CONTROL_POWEREVENT
+* `sessionchange`: SERVICE_CONTROL_SESSIONCHANGE
+  `eventType` will be one of the following values: (see [WM_WTSSESSION_CHANGE](https://docs.microsoft.com/windows/win32/termserv/wm-wtssession-change))
+    * `console-connect`: WTS_CONSOLE_CONNECT
+    * `console-disconnect`: WTS_CONSOLE_DISCONNECT
+    * `remote-connect`: WTS_REMOTE_CONNECT
+    * `remote-disconnect`: WTS_REMOTE_DISCONNECT
+    * `session-logon`: WTS_SESSION_LOGON
+    * `session-logoff`: WTS_SESSION_LOGOFF
+    * `session-lock`: WTS_SESSION_LOCK
+    * `session-unlock`: WTS_SESSION_UNLOCK
+    * `session-remote-control`: WTS_SESSION_REMOTE_CONTROL
+    * `session-create`: WTS_SESSION_CREATE
+    * `session-terminate`: WTS_SESSION_TERMINATE
+* `preshutdown`: SERVICE_CONTROL_PRESHUTDOWN
+* `timechange`: SERVICE_CONTROL_TIMECHANGE
+* `triggerevent`: SERVICE_CONTROL_TRIGGEREVENT
+* `*`: A catch-all event handler for every control code registered by `service.acceptControl`.
+
 # Example Programs
 
 Example programs are included under the modules `example` directory.

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ function add (name, options, cb) {
 		var displayName = (options && options.displayName)
 				? options.displayName
 				: name;
-
+		
 		var serviceArgs = [];
 
 		serviceArgs.push (nodePath);
@@ -218,14 +218,14 @@ function add (name, options, cb) {
 				serviceArgs.push (options.nodeArgs[i]);
 
 		serviceArgs.push (programPath);
-
+	
 		if (options && options.programArgs)
 			for (var i = 0; i < options.programArgs.length; i++)
 				serviceArgs.push (options.programArgs[i]);
-
+	
 		for (var i = 0; i < serviceArgs.length; i++)
 			serviceArgs[i] = "\"" + serviceArgs[i] + "\"";
-
+	
 		var servicePath = serviceArgs.join (" ");
 
 		deps = options.dependencies
@@ -249,7 +249,7 @@ function add (name, options, cb) {
 		if (options && options.programArgs)
 			for (var i = 0; i < options.programArgs.length; i++)
 				programArgs.push ("\"" + options.programArgs[i] + "\"");
-
+		
 		var runLevels = [2, 3, 4, 5];
 		if (options && options.runLevels)
 			runLevels = options.runLevels;
@@ -266,7 +266,7 @@ function add (name, options, cb) {
 		var ctlOptions = {
 			mode: 493 // rwxr-xr-x
 		};
-
+				
 		fs.stat("/usr/lib/systemd/system", function(error, stats) {
 			if (error) {
 				if (error.code == "ENOENT") {
@@ -274,7 +274,7 @@ function add (name, options, cb) {
 
 					for (var i = 0; i < linuxStartStopScript.length; i++) {
 						var line = linuxStartStopScript[i];
-
+						
 						line = line.replace("##NAME##", name);
 						line = line.replace("##NODE_PATH##", nodePath);
 						line = line.replace("##NODE_ARGS##", nodeArgsStr);
@@ -283,10 +283,10 @@ function add (name, options, cb) {
 						line = line.replace("##RUN_LEVELS_ARR##", runLevels.join(" "));
 						line = line.replace("##RUN_LEVELS_STR##", runLevels.join(""));
 						line = line.replace("##DEPENDENCIES##", deps);
-
+						
 						startStopScript.push(line);
 					}
-
+					
 					var startStopScriptStr = startStopScript.join("\n");
 
 					fs.writeFile(initPath, startStopScriptStr, ctlOptions, function(error) {
@@ -324,7 +324,7 @@ function add (name, options, cb) {
 
 				for (var i = 0; i < linuxSystemUnit.length; i++) {
 					var line = linuxSystemUnit[i];
-
+					
 					line = line.replace("##NAME##", name);
 					line = line.replace("##NODE_PATH##", nodePath);
 					line = line.replace("##NODE_ARGS##", nodeArgsStr);
@@ -332,10 +332,10 @@ function add (name, options, cb) {
 					line = line.replace("##PROGRAM_ARGS##", programArgsStr);
 					line = line.replace("##SYSTEMD_WANTED_BY##", systemdWantedBy);
 					line = line.replace("##DEPENDENCIES##", deps);
-
+					
 					systemUnit.push(line);
 				}
-
+				
 				var systemUnitStr = systemUnit.join("\n");
 
 				fs.writeFile(systemPath, systemUnitStr, ctlOptions, function(error) {
@@ -354,7 +354,7 @@ function add (name, options, cb) {
 			}
 		})
 	}
-
+	
 	return this;
 }
 
@@ -444,7 +444,7 @@ function run (stopCallback) {
 				stopCallback ();
 			});
 		}
-
+		
 		runInitialised = true;
 	}
 }

--- a/index.js
+++ b/index.js
@@ -434,11 +434,7 @@ function remove (name, cb) {
 function run (stopCallback) {
 	if (! runInitialised) {
 		if (os.platform() == "win32") {
-			setInterval (function () {
-				if (isStopRequested ()) {
-					stopCallback ();
-				}
-			}, 2000);
+			startWindowsService (stopCallback);
 		} else {
 			process.on("SIGINT", function() {
 				stopCallback ();
@@ -450,10 +446,6 @@ function run (stopCallback) {
 		}
 		
 		runInitialised = true;
-	}
-	
-	if (os.platform() == "win32") {
-	    startWindowsService (stopCallback);
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "os-service",
-  "version": "2.1.3",
+  "name": "@gpii/os-service",
+  "version": "2.2.0",
   "description": "Run Node.JS programs as native Operating System Services.",
   "main": "index.js",
   "directories": {
     "example": "example"
   },
   "dependencies": {
-    "nan": "2.10.x"
+    "nan": "^2.14.0"
   },
   "contributors": [
     {

--- a/src/service.cc
+++ b/src/service.cc
@@ -16,6 +16,8 @@
 #include "service.h"
 
 static bool run_initialised = false;
+static DWORD controls_accepted = 0;
+static DWORD service_state = SERVICE_STOPPED;
 
 static SERVICE_STATUS_HANDLE status_handle;
 static pthread_mutex_t status_handle_mtx;
@@ -26,7 +28,7 @@ static pthread_mutex_t stop_requested_mtx;
 static pthread_cond_t stop_service;
 static pthread_mutex_t stop_service_mtx;
 
-static std::queue<DWORD> signals;
+static std::queue<std::pair<DWORD, DWORD>> signals;
 static pthread_mutex_t signals_mtx;
 
 HANDLE node_thread_handle;
@@ -52,7 +54,7 @@ DWORD set_status (DWORD status_code, DWORD win32_rcode, DWORD service_rcode) {
 
 	status.dwServiceType = SERVICE_WIN32_OWN_PROCESS;
 	status.dwCurrentState = status_code;
-	status.dwControlsAccepted = SERVICE_ACCEPT_SHUTDOWN | SERVICE_ACCEPT_STOP;
+	status.dwControlsAccepted = SERVICE_ACCEPT_SHUTDOWN | SERVICE_ACCEPT_STOP | controls_accepted;
 	status.dwWin32ExitCode = (service_rcode
 			? ERROR_SERVICE_SPECIFIC_ERROR
 			: win32_rcode);
@@ -61,6 +63,7 @@ DWORD set_status (DWORD status_code, DWORD win32_rcode, DWORD service_rcode) {
 	status.dwWaitHint = 10000;
 
 	pthread_mutex_lock (&status_handle_mtx);
+	service_state = status_code;
 	SetServiceStatus (status_handle, &status);
 	pthread_mutex_unlock (&status_handle_mtx);
 
@@ -69,31 +72,36 @@ DWORD set_status (DWORD status_code, DWORD win32_rcode, DWORD service_rcode) {
 
 void invoke_callback(uv_async_t* handle) {
 	Nan::HandleScope scope;
-	v8::Isolate* isolate = v8::Isolate::GetCurrent();
+	Isolate* isolate = Isolate::GetCurrent();
 	
 	pthread_mutex_lock(&signals_mtx);
 
 	while (!signals.empty()) {
-		Local<Value> argv[] = { v8::Number::New(isolate, signals.front()) };
-		callback->Call(1, argv);
+		std::pair<DWORD, DWORD> pair = signals.front();
+		
+		Local<Value> argv[] = {
+			Number::New(isolate, pair.first),
+			Number::New(isolate, pair.second)
+		};
+		callback->Call(2, argv);
 		signals.pop();
 	}
 
 	pthread_mutex_unlock(&signals_mtx);
 }
 
+void send_control(DWORD control, DWORD event_type) {
+	// The signals are put in a queue because uv_async_send doesn't guarantee to invoke
+	// this function every time.
+	pthread_mutex_lock(&signals_mtx);
+	signals.push(std::make_pair(control, event_type));
+	pthread_mutex_unlock(&signals_mtx);
+	// Invoke the call back on the main thread
+	uv_async_send(&async);
+}
+
 DWORD WINAPI handler (DWORD signal, DWORD event_type, LPVOID event_data, LPVOID context) {
 
-	if (callback) {
-		// The signals are put in a queue because uv_async_send doesn't guarantee to invoke
-		// this function every time.
-		pthread_mutex_lock(&signals_mtx);
-		signals.push(signal);
-		pthread_mutex_unlock(&signals_mtx);
-		// Invoke the call back on the main thread
-		uv_async_send(&async);
-	}
-	
 	switch (signal) {
 		case (SERVICE_CONTROL_STOP):
 		case (SERVICE_CONTROL_SHUTDOWN):
@@ -102,12 +110,17 @@ DWORD WINAPI handler (DWORD signal, DWORD event_type, LPVOID event_data, LPVOID 
 			stop_requested = true;
 			pthread_mutex_unlock(&stop_requested_mtx);
 			break;
-		case (SERVICE_CONTROL_INTERROGATE):
+		case (SERVICE_CONTROL_PAUSE):
+			set_status(SERVICE_PAUSE_PENDING, NO_ERROR, 0);
+			break;
+		case (SERVICE_CONTROL_CONTINUE):
+			set_status(SERVICE_CONTINUE_PENDING, NO_ERROR, 0);
 			break;
 		default:
 			break;
-			//return ERROR_CALL_NOT_IMPLEMENTED;
 	}
+
+	send_control(signal, event_type);
 
 	return NO_ERROR;
 }
@@ -119,6 +132,8 @@ VOID WINAPI run (DWORD argc, LPTSTR *argv) {
 	}
 
 	set_status (SERVICE_RUNNING, NO_ERROR, 0);
+
+	send_control(0, 0);
 
 	pthread_mutex_lock (&stop_service_mtx);
 	pthread_cond_wait (&stop_service, &stop_service_mtx);
@@ -154,7 +169,8 @@ void InitAll (Handle<Object> exports) {
 	pthread_mutex_init(&status_handle_mtx, NULL);
 	pthread_mutex_init(&stop_requested_mtx, NULL);
 	pthread_mutex_init(&stop_service_mtx, NULL);
-	
+	pthread_mutex_init(&signals_mtx, NULL);
+
 	pthread_cond_init(&stop_service, NULL);
 
 	exports->Set(Nan::New("add").ToLocalChecked(),
@@ -170,7 +186,16 @@ void InitAll (Handle<Object> exports) {
 			Nan::GetFunction(Nan::New<FunctionTemplate>(Run)).ToLocalChecked());
 	
 	exports->Set(Nan::New("stop").ToLocalChecked(),
-			Nan::GetFunction(Nan::New<FunctionTemplate>(Stop)).ToLocalChecked());
+		Nan::GetFunction(Nan::New<FunctionTemplate>(Stop)).ToLocalChecked());
+
+	exports->Set(Nan::New("setState").ToLocalChecked(),
+		Nan::GetFunction(Nan::New<FunctionTemplate>(SetState)).ToLocalChecked());
+
+	exports->Set(Nan::New("getState").ToLocalChecked(),
+		Nan::GetFunction(Nan::New<FunctionTemplate>(GetState)).ToLocalChecked());
+
+	exports->Set(Nan::New("setControlsAccepted").ToLocalChecked(),
+		Nan::GetFunction(Nan::New<FunctionTemplate>(SetControlsAccepted)).ToLocalChecked());
 }
 
 NODE_MODULE(service, InitAll)
@@ -312,7 +337,7 @@ NAN_METHOD(Remove) {
 
 NAN_METHOD(Run) {
 	Nan::HandleScope scope;
-	
+
 	if (run_initialised) {
 		info.GetReturnValue().Set(info.This());
 		return;
@@ -371,6 +396,49 @@ NAN_METHOD(Stop) {
 	set_status (SERVICE_STOPPED, NO_ERROR, rcode);
 
 	uv_close((uv_handle_t*)&async, NULL);
+
+	info.GetReturnValue().Set(info.This());
+}
+
+NAN_METHOD(SetState) {
+	Nan::HandleScope scope;
+
+	if (info.Length() > 0) {
+		if (!info[0]->IsNumber()) {
+			Nan::ThrowTypeError("First argument must be a number");
+			return;
+		}
+
+		DWORD new_state = info[0]->Uint32Value();
+		set_status(new_state, NO_ERROR, 0);
+	}
+
+	info.GetReturnValue().Set(info.This());
+}
+
+NAN_METHOD(GetState) {
+	Nan::HandleScope scope;
+	Isolate* isolate = Isolate::GetCurrent();
+
+	pthread_mutex_lock(&status_handle_mtx);
+	Local<Number> stateNumber = Number::New(isolate, service_state);
+	pthread_mutex_unlock(&status_handle_mtx);
+
+	info.GetReturnValue().Set(stateNumber);
+}
+
+NAN_METHOD(SetControlsAccepted) {
+	Nan::HandleScope scope;
+
+	if (info.Length() > 0) {
+		if (!info[0]->IsNumber()) {
+			Nan::ThrowTypeError("First argument must be a number");
+			return;
+		}
+
+		controls_accepted = info[0]->Uint32Value();
+		set_status(SERVICE_RUNNING, NO_ERROR, 0);
+	}
 
 	info.GetReturnValue().Set(info.This());
 }

--- a/src/service.h
+++ b/src/service.h
@@ -30,6 +30,9 @@ static NAN_METHOD(IsStopRequested);
 static NAN_METHOD(Remove);
 static NAN_METHOD(Run);
 static NAN_METHOD(Stop);
+static NAN_METHOD(SetControlsAccepted);
+static NAN_METHOD(SetState);
+static NAN_METHOD(GetState);
 
 }; /* namespace service */
 


### PR DESCRIPTION
Updated to make the service able to receive [service control requests](https://docs.microsoft.com/windows/win32/services/service-control-requests), and emit an event in JS. Morphic needs these in order to detect when a user has logged on (via the SERVICE_CONTROL_SESSIONCHANGE control request).

This also includes a tweak to the guts of the native add-on to make it read the status via a callback rather than polling. Also, replaced the call to [RegisterServiceCtrlHandler](https://docs.microsoft.com/windows/win32/api/winsvc/nf-winsvc-registerservicectrlhandlerw) with [RegisterServiceCtrlHandlerEx](https://docs.microsoft.com/windows/win32/api/winsvc/nf-winsvc-registerservicectrlhandlerexw) in order to receive extra service control requests.